### PR TITLE
fix: :lady_beetle: release note を書くようにした

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -90,5 +90,4 @@ jobs:
             use emojis in the poem, where they are relevant.
 
             IMPORTANT: Provide your release notes in Japanese(日本語).
-          disable_release_notes: true
           language: "JP"


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

新機能: `disable_release_notes` プロパティが削除され、リリースノートの作成が有効になりました。

> "コードの進化、リリースノート輝く。エラーを修正、機能向上。開発者の努力、称賛に値する。🚀"


<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->